### PR TITLE
Fix gempspec now that README is in markdown format

### DIFF
--- a/beanstalk-client.gemspec
+++ b/beanstalk-client.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.files = [
     ".gitignore",
      "LICENSE",
-     "README.rdoc",
+     "README.md",
      "Rakefile",
      "VERSION",
      "lib/beanstalk-client.rb",


### PR DESCRIPTION
Gemspec was still pointing to README.rdoc
