### PR TITLE
Round robin through connections in pool

### DIFF
--- a/lib/beanstalk-client/connection.rb
+++ b/lib/beanstalk-client/connection.rb
@@ -290,16 +290,16 @@ module Beanstalk
     # * <tt>delay</tt>: how long to wait until making the job available for reservation
     # * <tt>ttr</tt>: time in seconds for the job to reappear on the queue (if beanstalk doesn't hear from a consumer within this time, assume the consumer died and make the job available for someone else to process).  Default 120 seconds.
     def put(body, pri=65536, delay=0, ttr=120)
-      send_to_rand_conn(:put, body, pri, delay, ttr)
+      send_to_single_conn(:put, body, pri, delay, ttr)
     end
 
     # Like put, but serialize the object with YAML.
     def yput(obj, pri=65536, delay=0, ttr=120)
-      send_to_rand_conn(:yput, obj, pri, delay, ttr)
+      send_to_single_conn(:yput, obj, pri, delay, ttr)
     end
 
     def on_tube(tube, &block)
-      send_to_rand_conn(:on_tube, tube, &block)
+      send_to_single_conn(:on_tube, tube, &block)
     end
 
     # Reserve a job from the queue.
@@ -308,7 +308,7 @@ module Beanstalk
     #
     # * <tt>timeout</tt> - Time (in seconds) to wait for a job to be available. If nil, wait indefinitely.
     def reserve(timeout=nil)
-      send_to_rand_conn(:reserve, timeout)
+      send_to_single_conn(:reserve, timeout)
     end
 
     def use(tube)
@@ -317,13 +317,13 @@ module Beanstalk
 
     def watch(tube)
       r = send_to_all_conns(:watch, tube)
-      @watch_list = send_to_rand_conn(:list_tubes_watched, true)
+      @watch_list = send_to_single_conn(:list_tubes_watched, true)
       return r
     end
 
     def ignore(tube)
       r = send_to_all_conns(:ignore, tube)
-      @watch_list = send_to_rand_conn(:list_tubes_watched, true)
+      @watch_list = send_to_single_conn(:list_tubes_watched, true)
       return r
     end
 
@@ -414,7 +414,7 @@ module Beanstalk
       retry_wrap{open_connections.inject(nil) {|r,c| r or call_wrap(c, *args)}}
     end
 
-    def send_to_rand_conn(*args, &block)
+    def send_to_single_conn(*args, &block)
       connect()
       retry_wrap{call_wrap(pick_connection, *args, &block)}
     end
@@ -425,7 +425,10 @@ module Beanstalk
     end
 
     def pick_connection()
-      open_connections[rand(open_connections.size)] or raise NotConnected
+      @connection_index = 0 if @connection_index.nil? || @connection_index >= open_connections.size
+      connection = open_connections[@connection_index] or raise NotConnected
+      @connection_index += 1
+      connection
     end
 
     def make_hash(pairs)


### PR DESCRIPTION
Switch from a random selection to round robin in order to
ensure a balanced approach to distributing puts and reserves.

Using a random selection in conjunction with an indefinite reserve
timeout can cause performance issues when there is a large imbalance
in current-jobs-ready between multiple servers.

(Example: A majority of puts happening on server1 while all workers are
waiting on server2)
