### PR TITLE
job_stats method

### DIFF
--- a/lib/beanstalk-client/connection.rb
+++ b/lib/beanstalk-client/connection.rb
@@ -192,6 +192,10 @@ module Beanstalk
       :ok
     end
 
+    def job_stats(id)
+      make_hash(send_to_all_conns(:job_stats, id))
+    end
+
     private
 
     def interact(cmd, rfmt)

--- a/lib/beanstalk-client/connection.rb
+++ b/lib/beanstalk-client/connection.rb
@@ -192,10 +192,6 @@ module Beanstalk
       :ok
     end
 
-    def job_stats(id)
-      make_hash(send_to_all_conns(:job_stats, id))
-    end
-
     private
 
     def interact(cmd, rfmt)
@@ -399,6 +395,10 @@ module Beanstalk
     
     def pause_tube(tube, delay)
       send_to_all_conns(:pause_tube, tube, delay)
+    end
+
+    def job_stats(id)
+      make_hash(send_to_all_conns(:job_stats, id))
     end
 
     private


### PR DESCRIPTION
Just 5cddc214 is needed.   The later commits are me trying to fix my Github username (fruitlessly :).   The job_stats method was unavailable without this very minor, minor, commit.

Thanks,

-Dave
