### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ You can also specify additional metadata to control job processing parameters. S
 you can set the `priority`, `delay`, and `ttr` of a particular job:
 
 ```ruby
-# defaults are priority 0, delay of 0 and ttr of 120 seconds
+# defaults are priority 65536, delay of 0 and ttr of 120 seconds
 @beanstalk.put "job-data-here", 1000, 50, 200
 ```
 


### PR DESCRIPTION
A typo in the comments of a ruby block has a typo. It states priority is defaulted to zero, but in actuality it is 65536 as stated here: https://github.com/kr/beanstalk-client-ruby/blob/master/lib/beanstalk-client/connection.rb#L53
